### PR TITLE
Adaption to avoid line break, but still show full text

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,7 +85,7 @@ android {
             buildConfigField(
                 type = "String",
                 name = "apiBaseUrl",
-                value = "\"https://backend.irfc-test.fh-joanneum.at/api/\""
+                value = "\"https://backend.irfc.fh-joanneum.at/api/\""
             )
             // Use a new prefix for each debug build to make testing easier
             buildConfigField(

--- a/app/src/main/java/at/irfc/app/ui/core/BottomBar.kt
+++ b/app/src/main/java/at/irfc/app/ui/core/BottomBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.navigation.NavController
 import at.irfc.app.R
 import at.irfc.app.generated.navigation.NavGraphs
@@ -53,7 +54,14 @@ fun BottomBar(
                         contentDescription = stringResource(destination.label)
                     )
                 },
-                label = { Text(stringResource(destination.label)) },
+                label = {
+                    Text(
+                        text = stringResource(destination.label),
+                        maxLines = 1,
+                        softWrap = false,
+                        overflow = TextOverflow.Visible
+                    )
+                },
                 colors = NavigationBarItemDefaults.colors(
                     selectedIconColor = IrfcYellow,
                     selectedTextColor = IrfcYellow,


### PR DESCRIPTION
# 💻 What
Adaption in bottom nav bar

# ❓ Why
on small device (width 720) "Programm" had second line with second m

# 📘 How
in label of bottom nav bar
set softwrap to false and add visibility for overflow, allow only 1 line

# 👀 See
Screenshots
<!-- i.e. <img src="" width="300px"> -->