### PR TITLE
check permission canScheduleExactAlarms

### DIFF
--- a/app/src/main/java/at/irfc/app/presentation/program/NotificationScheduler.kt
+++ b/app/src/main/java/at/irfc/app/presentation/program/NotificationScheduler.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import at.irfc.app.data.local.entity.Event
 import java.time.ZoneId
 
@@ -16,7 +17,9 @@ object NotificationScheduler {
     fun scheduleNotification(context: Context, event: Event) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
-        if (!alarmManager.canScheduleExactAlarms()) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            !alarmManager.canScheduleExactAlarms()
+        ) {
             // Optional: Direct user to settings - needed for Android >= 14
             val intent = Intent(
                 android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM

--- a/app/src/main/java/at/irfc/app/presentation/program/NotificationScheduler.kt
+++ b/app/src/main/java/at/irfc/app/presentation/program/NotificationScheduler.kt
@@ -5,15 +5,28 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import at.irfc.app.data.local.entity.Event
 import java.time.ZoneId
 
 object NotificationScheduler {
     private const val CACHE_VALIDITY_DURATION_MINUTES = 15
 
-    @SuppressLint("ScheduleExactAlarm")
+    @SuppressLint("ScheduleExactAlarm", "NewApi")
     fun scheduleNotification(context: Context, event: Event) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        if (!alarmManager.canScheduleExactAlarms()) {
+            // Optional: Direct user to settings - needed for Android >= 14
+            val intent = Intent(
+                android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
+            ).apply {
+                data = Uri.parse("package:${context.packageName}")
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+            return
+        }
 
         val intent = Intent(context, EventReminderReceiver::class.java).apply {
             putExtra("title", event.title)


### PR DESCRIPTION
# 💻 What
Check if alarm permission is set for the app. If not set, the settings will open automatically. User must grant permission.

# ❓ Why
App crashes when setting a favorite on Android 14 and higher.

# 📘 How
- Setting an event as a favorite on Android 14 or higher.
- The event must be in the future for the alarm to be set.
- If the alarm permission is not set, a window will open where the permission must be set.
- The permission only needs to be set once.

# 👀 See
Screenshots
<!-- i.e. <img src="" width="300px"> -->
![SetPermission](https://github.com/user-attachments/assets/68997c0c-f758-48a1-bfb3-82db4244d897)
