### PR TITLE
Keep local favorite status

### DIFF
--- a/app/src/main/java/at/irfc/app/data/local/dao/EventDao.kt
+++ b/app/src/main/java/at/irfc/app/data/local/dao/EventDao.kt
@@ -30,6 +30,9 @@ abstract class EventDao(private val database: IrfcDatabase) {
     @Query("DELETE FROM events WHERE eventId = :id")
     abstract suspend fun deleteById(id: Long)
 
+    @Query("SELECT eventId, isFavorite FROM events")
+    abstract suspend fun getAllFavoritesRaw(): List<EventFavoriteStatus>
+
     @Update
     abstract suspend fun updateEvent(event: Event)
 

--- a/app/src/main/java/at/irfc/app/data/local/dao/EventDao.kt
+++ b/app/src/main/java/at/irfc/app/data/local/dao/EventDao.kt
@@ -6,6 +6,7 @@ import at.irfc.app.data.local.entity.*
 import at.irfc.app.data.local.entity.relations.EventWithDetails
 import kotlinx.coroutines.flow.Flow
 
+@Suppress("TooManyFunctions")
 @Dao
 abstract class EventDao(private val database: IrfcDatabase) {
 

--- a/app/src/main/java/at/irfc/app/data/local/entity/EventFavoriteStatus.kt
+++ b/app/src/main/java/at/irfc/app/data/local/entity/EventFavoriteStatus.kt
@@ -1,0 +1,6 @@
+package at.irfc.app.data.local.entity
+
+data class EventFavoriteStatus(
+    val eventId: Long,
+    val isFavorite: Boolean
+)

--- a/app/src/main/java/at/irfc/app/data/repository/EventRepository.kt
+++ b/app/src/main/java/at/irfc/app/data/repository/EventRepository.kt
@@ -5,7 +5,6 @@ import at.irfc.app.data.local.dao.EventDao
 import at.irfc.app.data.local.entity.EventCategory
 import at.irfc.app.data.local.entity.relations.EventWithDetails
 import at.irfc.app.data.remote.api.EventApi
-import at.irfc.app.data.remote.dto.EventDto
 import at.irfc.app.data.remote.dto.toEventEntity
 import at.irfc.app.util.Resource
 import at.irfc.app.util.cachedRemoteResource
@@ -22,7 +21,19 @@ class EventRepository(
     fun loadEvents(force: Boolean): Flow<Resource<List<EventWithDetails>>> = cachedRemoteResource(
         query = eventDao::getAll,
         fetch = eventApi::getEvents,
-        update = { eventDao.replaceEvents(it.map(EventDto::toEventEntity)) },
+        update = { eventDtos ->
+            val favoriteMap = eventDao.getAllFavoritesRaw()
+                .associate { it.eventId to it.isFavorite }
+
+            val eventWithDetailsList = eventDtos.map { dto ->
+                val fullDetails = dto.toEventEntity()
+                val isFavorite = favoriteMap[fullDetails.event.id] ?: false
+                val updatedEvent = fullDetails.event.copy(isFavorite = isFavorite)
+                fullDetails.copy(event = updatedEvent)
+            }
+
+            eventDao.replaceEvents(eventWithDetailsList)
+        },
         shouldFetch = { events ->
             val updateWhenOlderThan = LocalDateTime.now() - cacheDuration
             force || events.isEmpty() || events.any { it.updated.isBefore(updateWhenOlderThan) }


### PR DESCRIPTION
# 💻 What
Check local favorites status on refresh.

# ❓ Why
When the events were refreshed, previously set favorites were reset.

# 📘 How
- When events are reloaded from the backend, the locally set favorites are selected and retained during the update.
- Setting favorites
- then refresh
- the set favorites are retained

# 👀 See
